### PR TITLE
Major fix to remove several issues

### DIFF
--- a/nifi-witsml-service-api/src/main/java/org/hashmapinc/tempus/processors/witsml/IWitsmlServiceApi.java
+++ b/nifi-witsml-service-api/src/main/java/org/hashmapinc/tempus/processors/witsml/IWitsmlServiceApi.java
@@ -21,7 +21,9 @@ import java.util.List;
 public interface IWitsmlServiceApi extends ControllerService {
     Object getObject(String wellId, String wellboreId, String object);
     ObjLogs getLogData(String wellId, String wellboreId, String logId, LogRequestTracker logTracker);
+    ObjLogs getLogData(String wellId, String wellboreId, String logId, String startDepth, String startTime);
     ObjMudLogs getMudLogData(String wellId, String wellboreId, String mudLogId, MudlogRequestTracker mudlogTracker);
+    ObjTrajectorys getTrajectoryData(String wellId, String wellboreId, String trajectoryId, String startDepth);
     ObjTrajectorys getTrajectoryData(String wellId, String wellboreId, String trajectoryId, TrajectoryRequestTracker trajectoryTracker);
     List<WitsmlObjectId> getAvailableObjects(String uri, List<String> objectTypes, String wellFilter);
     Object getObjectData(String wellId, String wellboreId, String objType, String objectId, ObjectRequestTracker objectTracker);

--- a/nifi-witsml-service/src/main/java/org/hashmapinc/tempus/processors/witsml/Witsml1411Service.java
+++ b/nifi-witsml-service/src/main/java/org/hashmapinc/tempus/processors/witsml/Witsml1411Service.java
@@ -149,12 +149,22 @@ public class Witsml1411Service extends AbstractControllerService implements IWit
     }
 
     @Override
+    public ObjLogs getLogData(String wellId, String wellboreId, String logId, String startDepth, String startTime) {
+        return null;
+    }
+
+    @Override
     public ObjMudLogs getMudLogData(String wellId, String wellboreId, String mudLogId, MudlogRequestTracker mudLogTracker) {
         mudLogTracker.setVersion(WitsmlVersion.VERSION_1411);
         mudLogTracker.setMudlogId(mudLogId);
         mudLogTracker.initalize(myClient, wellId, wellboreId);
 
         return mudLogTracker.ExecuteRequest();
+    }
+
+    @Override
+    public ObjTrajectorys getTrajectoryData(String wellId, String wellboreId, String trajectoryId, String startDepth) {
+        return null;
     }
 
     @Override

--- a/nifi-witsml-service/src/main/resources/1311/GetLogDataQuery.xml
+++ b/nifi-witsml-service/src/main/resources/1311/GetLogDataQuery.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<logs version="1.3.1.1" xmlns="http://www.witsml.org/schemas/131">
+    <log uidWell="%uidWell%" uidWellbore="%uidWellbore%" uid="%uidLog%">
+        <nameWell />
+        <nameWellbore />
+        <name />
+        <objectGrowing />
+        <dataRowCount />
+        <serviceCompany />
+        <runNumber />
+        <pass />
+        <creationDate />
+        <description />
+        <indexType />
+        <startIndex uom="">%startIndex%</startIndex>
+        <endIndex uom="" />
+        <stepIncrement uom="" numerator="" denominator="" />
+        <startDateTimeIndex>%startDateTimeIndex%</startDateTimeIndex>
+        <endDateTimeIndex />
+        <direction />
+        <indexCurve columnIndex="" />
+        <nullValue />
+        <logParam index="" name="" uom="" description="" />
+        <logCurveInfo uid="">
+            <mnemonic />
+            <classWitsml />
+            <unit />
+            <mnemAlias />
+            <nullValue />
+            <minIndex uom="" />
+            <maxIndex uom="" />
+            <minDateTimeIndex />
+            <maxDateTimeIndex />
+            <columnIndex />
+            <curveDescription />
+            <sensorOffset uom="" />
+            <traceState />
+            <typeLogData />
+        </logCurveInfo>
+        <logData>
+            <data />
+        </logData>
+    </log>
+</logs>

--- a/nifi-witsml-service/src/main/resources/1311/GetTrajectoryData.xml
+++ b/nifi-witsml-service/src/main/resources/1311/GetTrajectoryData.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<trajectorys xmlns="http://www.witsml.org/schemas/131" version="1.3.1.1">
+    <trajectory uidWell="%uidWell%" uidWellbore="%uidWellbore%" uid="%uidTrajectory%">
+        <nameWell/>
+        <nameWellbore/>
+        <name/>
+        <objectGrowing/>
+        <parentTrajectory>
+            <trajectoryReference uidRef=""/>
+            <wellboreParent/>
+        </parentTrajectory>
+        <dTimTrajStart/>
+        <dTimTrajEnd/>
+        <mdMn uom="">%mdMn%</mdMn>
+        <mdMx uom=""/>
+        <serviceCompany/>
+        <magDeclUsed uom=""/>
+        <gridCorUsed uom=""/>
+        <aziVertSect uom=""/>
+        <dispNsVertSectOrig uom=""/>
+        <dispEwVertSectOrig uom=""/>
+        <definitive/>
+        <memory/>
+        <finalTraj/>
+        <aziRef/>
+        <trajectoryStation uid="">
+            <target/>
+            <dTimStn/>
+            <typeTrajStation/>
+            <md uom=""/>
+            <tvd uom=""/>
+            <incl uom=""/>
+            <azi uom=""/>
+            <mtf uom=""/>
+            <gtf uom=""/>
+            <dispNs uom=""/>
+            <dispEw uom=""/>
+            <vertSect uom=""/>
+            <dls uom=""/>
+            <rateTurn uom=""/>
+            <rateBuild uom=""/>
+            <mdDelta uom=""/>
+            <tvdDelta uom=""/>
+            <modelToolError/>
+            <gravTotalUncert uom=""/>
+            <dipAngleUncert uom=""/>
+            <magTotalUncert uom=""/>
+            <gravAccelCorUsed/>
+            <magXAxialCorUsed/>
+            <sagCorUsed/>
+            <magDrlstrCorUsed/>
+            <statusTrajStation/>
+            <gravTotalFieldReference/>
+            <magTotalFieldReference/>
+            <magDipAngleReference/>
+            <magModelUsed/>
+            <magModelValid/>
+            <geoModelUsed/>
+            <rawData>
+                <gravAxialRaw uom=""/>
+                <gravTran1Raw uom=""/>
+                <gravTran2Raw uom=""/>
+                <magAxialRaw uom=""/>
+                <magTran1Raw uom=""/>
+                <magTran2Raw uom=""/>
+            </rawData>
+            <corUsed>
+                <gravAxialAccelCor uom=""/>
+                <gravTran1AccelCor uom=""/>
+                <gravTran2AccelCor uom=""/>
+                <magAxialDrlstrCor uom=""/>
+                <magTran1DrlstrCor uom=""/>
+                <magTran2DrlstrCor uom=""/>
+                <sagIncCor uom=""/>
+                <sagAziCor uom=""/>
+                <stnMagDeclUsed uom=""/>
+                <stnGridCorUsed uom=""/>
+                <dirSensorOffset uom=""/>
+            </corUsed>
+            <valid>
+                <magTotalFieldCalc uom=""/>
+                <magDipAngleCalc uom=""/>
+                <gravTotalFieldCalc uom=""/>
+            </valid>
+            <matrixCov>
+                <varianceNN uom=""/>
+                <varianceNE uom=""/>
+                <varianceNVert uom=""/>
+                <varianceEE uom=""/>
+                <varianceEVert uom=""/>
+                <varianceVertVert uom=""/>
+                <biasN uom=""/>
+                <biasE uom=""/>
+                <biasVert uom=""/>
+            </matrixCov>
+            <location uid="">
+                <wellCRS uidRef=""/>
+                <latitude uom=""/>
+                <longitude uom=""/>
+                <easting/>
+                <northing/>
+                <westing/>
+                <southing/>
+                <projectedX/>
+                <projectedY/>
+                <localX/>
+                <localY/>
+                <original/>
+                <description/>
+            </location>
+        </trajectoryStation>
+        <commonData>
+            <itemState/>
+            <comments/>
+        </commonData>
+    </trajectory>
+</trajectorys>


### PR DESCRIPTION
The processor now only has 3 relationships:
Partial - where a result goes when the object is still growing
Success - Where an result goes when the object is done growing or is metadata
Failure - where an object goes dueo an error

Additionally there are properties set on the message:
object.type = the type of the object being returned:
depth
date time
trajectory
log curve info